### PR TITLE
ウィンドウリサイズ時に月の軌跡をクリアするように修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -358,6 +358,6 @@ function windowResized() {
     s.trail = s.trail.map(p => p5.Vector.add(p, offset));
   });
   
-  // 月の軌道も更新（必要なら）
-  moonTrail = moonTrail.map(p => p5.Vector.add(p, offset));
+  // リサイズ時は月の軌道をクリア
+  moonTrail = [];
 }


### PR DESCRIPTION
- ウィンドウリサイズ時に月の軌跡をクリアするように修正しました。\n- リサイズ後に月の軌跡が新しく描画されるため、より自然な動作になります。