### PR TITLE
refactor: ヘルパー関数をutilsディレクトリに移動

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+import { getRandomColor } from './utils/colors.js';
+
 // 定数
 const EARTH_RADIUS = 30; // 地球の半径（ピクセル）
 const MOON_RADIUS = 10; // 月の半径（ピクセル）
@@ -26,46 +28,6 @@ let explosionEffects = []; // 爆発エフェクトの配列
 let isResizing = false; // リサイズ中フラグ
 
 // 宇宙船クラス
-// ランダムな明るい色を生成する関数
-function getRandomColor() {
-  // HSLからRGBに変換する関数
-  function hslToRgb(h, s, l) {
-    let r, g, b;
-
-    if (s === 0) {
-      r = g = b = l; // アクロマティック
-    } else {
-      const hue2rgb = (p, q, t) => {
-        if (t < 0) t += 1;
-        if (t > 1) t -= 1;
-        if (t < 1/6) return p + (q - p) * 6 * t;
-        if (t < 1/2) return q;
-        if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
-        return p;
-      };
-
-      const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-      const p = 2 * l - q;
-      r = hue2rgb(p, q, h + 1/3);
-      g = hue2rgb(p, q, h);
-      b = hue2rgb(p, q, h - 1/3);
-    }
-
-    return [
-      Math.round(r * 255),
-      Math.round(g * 255),
-      Math.round(b * 255)
-    ];
-  }
-
-  // ランダムな色相（0-360）、高い彩度（70-100%）、高い明度（60-80%）
-  const h = Math.random();
-  const s = 0.7 + Math.random() * 0.3; // 70-100%
-  const l = 0.6 + Math.random() * 0.2; // 60-80%
-
-  return hslToRgb(h, s, l);
-}
-
 class Spacecraft {
   constructor(x, y, vx, vy) {
     this.position = createVector(x, y);

--- a/utils/colors.js
+++ b/utils/colors.js
@@ -1,0 +1,39 @@
+// ランダムな明るい色を生成する関数
+export function getRandomColor() {
+  // HSLからRGBに変換する関数
+  function hslToRgb(h, s, l) {
+    let r, g, b;
+
+    if (s === 0) {
+      r = g = b = l; // アクロマティック
+    } else {
+      const hue2rgb = (p, q, t) => {
+        if (t < 0) t += 1;
+        if (t > 1) t -= 1;
+        if (t < 1/6) return p + (q - p) * 6 * t;
+        if (t < 1/2) return q;
+        if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+        return p;
+      };
+
+      const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+      const p = 2 * l - q;
+      r = hue2rgb(p, q, h + 1/3);
+      g = hue2rgb(p, q, h);
+      b = hue2rgb(p, q, h - 1/3);
+    }
+
+    return [
+      Math.round(r * 255),
+      Math.round(g * 255),
+      Math.round(b * 255)
+    ];
+  }
+
+  // ランダムな色相（0-360）、高い彩度（70-100%）、高い明度（60-80%）
+  const h = Math.random();
+  const s = 0.7 + Math.random() * 0.3; // 70-100%
+  const l = 0.6 + Math.random() * 0.2; // 60-80%
+
+  return hslToRgb(h, s, l);
+}


### PR DESCRIPTION
## 変更内容

- getRandomColor関数をutils/colors.jsに移動
- app.jsからgetRandomColor関数を削除し、importに変更
- importをファイルの先頭に配置

## 変更理由

- コードの保守性と再利用性を向上
- ヘルパー関数を適切な場所で管理
- JavaScriptのベストプラクティスに従ったimportの配置