### PR TITLE
モバイル表示時にShiftキー+スワイプの説明を非表示に

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,14 @@
             border-radius: 5px;
             font-size: 14px;
         }
+        .pc-only {
+            display: block;
+        }
+        @media (max-width: 768px) {
+            .pc-only {
+                display: none;
+            }
+        }
     </style>
     <!-- p5.jsライブラリを読み込む -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.min.js"></script>
@@ -49,7 +57,7 @@
 <body>
     <div id="instructions">
         スワイプ/ドラッグで宇宙船を発射<br />
-        Shiftキー + スワイプ: レインボー<br />
+        <span class="pc-only">Shiftキー + スワイプ: レインボー<br /></span>
         地球をタップ: すべての宇宙船を消去<br />
     </div>
 </body>


### PR DESCRIPTION
## 変更内容

- モバイル端末（画面幅768px以下）では「Shiftキー + スワイプ: レインボー」の説明を非表示に
- PC（画面幅768pxより大きい）では表示を維持

## 実装方法
- 説明文をspan要素で囲み、pc-onlyクラスを適用
- メディアクエリを使用して、モバイル表示時に非表示となるように設定