### PR TITLE
月の角速度を円軌道速度に合わせて調整

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -2,7 +2,7 @@
 const EARTH_RADIUS = 30; // 地球の半径（ピクセル）
 const MOON_RADIUS = 10; // 月の半径（ピクセル）
 const MOON_DISTANCE = 200; // 月の軌道半径（ピクセル）
-const MOON_ANGULAR_VELOCITY = 0.025; // 月の角速度（円軌道速度に合わせて調整）
+const MOON_ANGULAR_VELOCITY = -0.025; // 月の角速度（円軌道速度に合わせて調整、反時計回りに変更）
 const TRAIL_LENGTH = 100; // 軌道の長さ（ポイント数）
 
 // 重力定数

--- a/js/constants.js
+++ b/js/constants.js
@@ -2,7 +2,7 @@
 const EARTH_RADIUS = 30; // 地球の半径（ピクセル）
 const MOON_RADIUS = 10; // 月の半径（ピクセル）
 const MOON_DISTANCE = 200; // 月の軌道半径（ピクセル）
-const MOON_ANGULAR_VELOCITY = 0.005; // 月の角速度
+const MOON_ANGULAR_VELOCITY = 0.025; // 月の角速度（円軌道速度に合わせて調整）
 const TRAIL_LENGTH = 100; // 軌道の長さ（ポイント数）
 
 // 重力定数

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,6 +1,6 @@
 // 定数
 const EARTH_RADIUS = 30; // 地球の半径（ピクセル）
-const MOON_RADIUS = 10; // 月の半径（ピクセル）
+const MOON_RADIUS = 8; // 月の半径（ピクセル）（地球との実際の大きさの比率に近づけた）
 const MOON_DISTANCE = 200; // 月の軌道半径（ピクセル）
 const MOON_ANGULAR_VELOCITY = -0.025; // 月の角速度（円軌道速度に合わせて調整、反時計回りに変更）
 const TRAIL_LENGTH = 100; // 軌道の長さ（ポイント数）

--- a/js/moon.js
+++ b/js/moon.js
@@ -24,7 +24,7 @@ function updateMoonAngle() {
 function drawMoon() {
   // 月の軌道を描画
   noFill();
-  stroke(100, 100, 100); // グレーの軌道
+  stroke(MOON_COLOR); // 月と同じ黄色の軌道
   beginShape();
   for (let i = 0; i < moonTrail.length; i++) {
     vertex(moonTrail[i].x, moonTrail[i].y);


### PR DESCRIPTION
月と同じ半径で宇宙船を回した時に、同じ速度になるように月の角速度を調整しました。

- 円軌道速度の計算式（v = √(GM/r)）に基づいて、月の角速度を0.005から0.025に変更
- これにより、月の軌道半径（200ピクセル）での円軌道速度と月の速度が一致するようになります